### PR TITLE
ciri crypto module

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
       lru_redux (~> 1.1.0)
       snappy (~> 0.0.17)
     ciri-rlp (0.1.1)
-      ciri-utils (~> 0.1.0)
+      ciri-utils (~> 0.2.0)
     ciri-utils (0.2.0)
       digest-sha3 (~> 1.1.0)
 
@@ -50,4 +50,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ciri (0.0.2)
       bitcoin-secp256k1 (~> 0.4.0)
-      ciri-crypto (~> 0.1.0)
+      ciri-crypto (~> 0.1.1)
       ciri-rlp (~> 0.1.1)
       ciri-utils (~> 0.2.0)
       concurrent-ruby (~> 1.0.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
       ffi (~> 1.9.23)
       lru_redux (~> 1.1.0)
       snappy (~> 0.0.17)
-    ciri-crypto (0.1.0)
+    ciri-crypto (0.1.1)
       bitcoin-secp256k1 (~> 0.4.0)
       ciri-utils (~> 0.2.0)
     ciri-rlp (0.1.1)

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ rescue LoadError
   nil
 end
 
-SUB_COMPONENTS = %w{ciri-utils ciri-rlp}
+SUB_COMPONENTS = %w{ciri-utils ciri-rlp ciri-crypto}
 
 desc 'run tests'
 task :test do

--- a/ciri-crypto/.gitignore
+++ b/ciri-crypto/.gitignore
@@ -1,0 +1,11 @@
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+
+# rspec failure tracking
+.rspec_status

--- a/ciri-crypto/.rspec
+++ b/ciri-crypto/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/ciri-crypto/.travis.yml
+++ b/ciri-crypto/.travis.yml
@@ -1,0 +1,5 @@
+sudo: false
+language: ruby
+rvm:
+  - 2.5.1
+before_install: gem install bundler -v 1.16.2

--- a/ciri-crypto/CODE_OF_CONDUCT.md
+++ b/ciri-crypto/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at classicalliu@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/ciri-crypto/Gemfile
+++ b/ciri-crypto/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# Specify your gem's dependencies in ciri-crypto.gemspec
+gemspec

--- a/ciri-crypto/Gemfile.lock
+++ b/ciri-crypto/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ciri-crypto (0.1.0)
+    ciri-crypto (0.1.1)
       bitcoin-secp256k1 (~> 0.4.0)
       ciri-utils (~> 0.2.0)
 

--- a/ciri-crypto/Gemfile.lock
+++ b/ciri-crypto/Gemfile.lock
@@ -1,34 +1,21 @@
 PATH
   remote: .
   specs:
-    ciri (0.0.2)
-      bitcoin-secp256k1 (~> 0.4.0)
-      ciri-crypto (~> 0.1.0)
-      ciri-rlp (~> 0.1.1)
-      ciri-utils (~> 0.2.0)
-      concurrent-ruby (~> 1.0.5)
-      ffi (~> 1.9.23)
-      lru_redux (~> 1.1.0)
-      snappy (~> 0.0.17)
     ciri-crypto (0.1.0)
       bitcoin-secp256k1 (~> 0.4.0)
       ciri-utils (~> 0.2.0)
-    ciri-rlp (0.1.1)
-      ciri-utils (~> 0.2.0)
-    ciri-utils (0.2.0)
-      digest-sha3 (~> 1.1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     bitcoin-secp256k1 (0.4.0)
       ffi (>= 1.9.10)
-    concurrent-ruby (1.0.5)
+    ciri-utils (0.2.0)
+      digest-sha3 (~> 1.1.0)
     diff-lcs (1.3)
     digest-sha3 (1.1.0)
     ffi (1.9.25)
-    lru_redux (1.1.0)
-    rake (10.3.2)
+    rake (10.5.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -42,14 +29,13 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    snappy (0.0.17)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bundler (~> 1.16)
-  ciri!
+  ciri-crypto!
   rake (~> 10.0)
   rspec (~> 3.0)
 

--- a/ciri-crypto/LICENSE.txt
+++ b/ciri-crypto/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 classicalliu
+Copyright (c) 2018 Jiang Jinyang, classicalliu
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/ciri-crypto/LICENSE.txt
+++ b/ciri-crypto/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 classicalliu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/ciri-crypto/README.md
+++ b/ciri-crypto/README.md
@@ -22,19 +22,21 @@ Or install it yourself as:
 
 ```ruby
   # signature
-  Ciri::Crypto.esdsa_signature(key, data)
+  Ciri::Crypto.esdsa_signature("\x00...(privkey)", "\x00...(data)")
   
   # recover
-  Ciri::Crypto.ecdsa_recover(msg, signature, return_raw_key: true)
+  Ciri::Crypto.ecdsa_recover("I\x90...(signed hash)", "f\xAA...(signature)", return_raw_key: true)
   
   # ecies encrypt
-  Ciri::Crypto.ecies_encrypt(message, raw_pubkey, shared_mac_data = '')
+  key = OpenSSL::PKey::EC.new('secp256k1')
+  key.generate_key 
+  encrypt_data = Ciri::Crypto.ecies_encrypt("hello ciri", key, shared_mac_data = '')
   
   # ecies decrypt
-  Ciri::Crypto.ecies_encrypt(data, private_key, shared_mac_data = '')
+  Ciri::Crypto.ecies_decrypt(encrypt_data, key, shared_mac_data = '')
   
   # ensure secp256k1 key 
-  Ciri::Crypto.ensure_secp256k1_key(private_key) 
+  Ciri::Crypto.ensure_secp256k1_key(privkey: "\x00...") 
 ```
 
 ## Development

--- a/ciri-crypto/README.md
+++ b/ciri-crypto/README.md
@@ -1,0 +1,56 @@
+# Ciri::Crypto
+
+Crypto module of [Ciri](https://github.com/ciri-ethereum/ciri)
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'ciri-crypto'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install ciri-crypto
+
+## Usage
+
+```ruby
+  # signature
+  Ciri::Crypto.esdsa_signature(key, data)
+  
+  # recover
+  Ciri::Crypto.ecdsa_recover(msg, signature, return_raw_key: true)
+  
+  # ecies encrypt
+  Ciri::Crypto.ecies_encrypt(message, raw_pubkey, shared_mac_data = '')
+  
+  # ecies decrypt
+  Ciri::Crypto.ecies_encrypt(data, private_key, shared_mac_data = '')
+  
+  # ensure secp256k1 key 
+  Ciri::Crypto.ensure_secp256k1_key(private_key) 
+```
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/ciri-crypto. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+
+## License
+
+The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+
+## Code of Conduct
+
+Everyone interacting in the Ciri::Crypto project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/ciri-crypto/blob/master/CODE_OF_CONDUCT.md).

--- a/ciri-crypto/Rakefile
+++ b/ciri-crypto/Rakefile
@@ -1,0 +1,6 @@
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/ciri-crypto/bin/console
+++ b/ciri-crypto/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "ciri/crypto"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/ciri-crypto/bin/setup
+++ b/ciri-crypto/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/ciri-crypto/ciri-crypto.gemspec
+++ b/ciri-crypto/ciri-crypto.gemspec
@@ -6,8 +6,8 @@ require "ciri/crypto/version"
 Gem::Specification.new do |spec|
   spec.name          = "ciri-crypto"
   spec.version       = Ciri::Crypto::VERSION
-  spec.authors       = ["classicalliu"]
-  spec.email         = ["classicalliu@gmail.com"]
+  spec.authors       = ["classicalliu", "Jiang Jinyang"]
+  spec.email         = ["classicalliu@gmail.com", "jjyruby@gmail.com"]
 
   spec.summary       = %q{Crypto module of [Ciri](https://github.com/ciri-ethereum/ciri)}
   spec.description   = %q{A Ciri crypto module}

--- a/ciri-crypto/ciri-crypto.gemspec
+++ b/ciri-crypto/ciri-crypto.gemspec
@@ -1,0 +1,40 @@
+
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "ciri/crypto/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "ciri-crypto"
+  spec.version       = Ciri::Crypto::VERSION
+  spec.authors       = ["classicalliu"]
+  spec.email         = ["classicalliu@gmail.com"]
+
+  spec.summary       = %q{Crypto module of [Ciri](https://github.com/ciri-ethereum/ciri)}
+  spec.description   = %q{A Ciri crypto module}
+  spec.homepage      = "https://github.com/ciri-ethereum/ciri"
+  spec.license       = "MIT"
+
+  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
+  # to allow pushing to a single host or delete this section to allow pushing to any host.
+  if spec.respond_to?(:metadata)
+    spec.metadata["allowed_push_host"] = "https://rubygems.org/"
+  else
+    raise "RubyGems 2.0 or newer is required to protect against " \
+      "public gem pushes."
+  end
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_dependency "ciri-utils", "~> 0.2.0"
+  spec.add_dependency 'bitcoin-secp256k1', '~> 0.4.0'
+end

--- a/ciri-crypto/lib/ciri/crypto.rb
+++ b/ciri-crypto/lib/ciri/crypto.rb
@@ -28,9 +28,8 @@ require 'openssl'
 require 'ciri/utils'
 require 'secp256k1'
 
-require_relative "./crypto/errors"
-require_relative "./crypto/signature"
-require_relative "./key"
+require_relative "crypto/errors"
+require_relative "crypto/signature"
 
 module Ciri
   module Crypto

--- a/ciri-crypto/lib/ciri/crypto/errors.rb
+++ b/ciri-crypto/lib/ciri/crypto/errors.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2018, by Jiang Jinyang. <https://justjjy.com>, classicalliu.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+module Ciri
+  module Crypto
+    class Error < StandardError
+    end
+
+    class ECIESDecryptionError < Error
+    end
+
+    class ECDSASignatureError < Error
+    end
+  end
+end

--- a/ciri-crypto/lib/ciri/crypto/signature.rb
+++ b/ciri-crypto/lib/ciri/crypto/signature.rb
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 
 require "ciri/utils"
-require_relative "./errors"
+require_relative "errors"
 
 module Ciri
   module Crypto

--- a/ciri-crypto/lib/ciri/crypto/signature.rb
+++ b/ciri-crypto/lib/ciri/crypto/signature.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2018, by Jiang Jinyang. <https://justjjy.com>, classicalliu.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require "ciri/utils"
+require_relative "./errors"
+
+module Ciri
+  module Crypto
+
+    SECP256K1N = 115792089237316195423570985008687907852837564279074904382605163141518161494337
+
+    class Signature
+      attr_reader :r, :s, :v
+
+      def initialize(signature: nil, vrs: nil)
+        if !!signature == !!vrs
+          raise ArgumentError.new("should pass signature_bytes or vrs, but can't provide both together")
+        end
+
+        if signature
+          unless signature.size == 65
+            raise ECDSASignatureError.new("signature size should be 65, got: #{signature.size}")
+          end
+
+          @r = Utils.big_endian_decode(signature[0...32])
+          @s = Utils.big_endian_decode(signature[32...64])
+          @v = Utils.big_endian_decode(signature[64])
+        else
+          @v, @r, @s = vrs
+
+          unless self.signature.size == 65
+            raise ECDSASignatureError.new("vrs is incorrect")
+          end
+        end
+      end
+
+      def signature
+        @signature ||= Utils.big_endian_encode(@r, "\x00".b, size: 32) +
+          Utils.big_endian_encode(@s, "\x00".b, size: 32) +
+          Utils.big_endian_encode(@v, "\x00".b)
+      end
+
+      alias to_s signature
+
+      def valid?
+        v <= 1 &&
+          r < SECP256K1N && r >= 1 &&
+          s < SECP256K1N && s >= 1
+      end
+
+      def low_s?
+        s < (SECP256K1N / 2)
+      end
+    end
+
+  end
+end

--- a/ciri-crypto/lib/ciri/crypto/version.rb
+++ b/ciri-crypto/lib/ciri/crypto/version.rb
@@ -1,5 +1,5 @@
 module Ciri
   module Crypto
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end

--- a/ciri-crypto/lib/ciri/crypto/version.rb
+++ b/ciri-crypto/lib/ciri/crypto/version.rb
@@ -1,0 +1,5 @@
+module Ciri
+  module Crypto
+    VERSION = "0.1.0"
+  end
+end

--- a/ciri-crypto/lib/ciri/key.rb
+++ b/ciri-crypto/lib/ciri/key.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) 2018, by Jiang Jinyang. <https://justjjy.com>
+# Copyright (c) 2018, by Jiang Jinyang. <https://justjjy.com>, classicalliu.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,6 +22,7 @@
 
 
 require 'openssl'
+require 'ciri/utils'
 require_relative 'crypto'
 
 module Ciri

--- a/ciri-crypto/spec/ciri/crypto_spec.rb
+++ b/ciri-crypto/spec/ciri/crypto_spec.rb
@@ -22,8 +22,8 @@
 
 
 # require 'spec_helper'
+require 'openssl'
 require 'ciri/crypto'
-require 'ciri/key'
 
 RSpec.describe Ciri::Crypto do
   it 'self consistent' do
@@ -37,10 +37,17 @@ RSpec.describe Ciri::Crypto do
 
   context 'ecdsa recover' do
     it 'self consistent' do
-      key = Ciri::Key.random
+      ec_key = OpenSSL::PKey::EC.new('secp256k1')
+      ec_key.generate_key
+
       msg = Ciri::Utils.keccak "hello world"
-      signature = key.ecdsa_signature(msg)
-      expect(Ciri::Key.ecdsa_recover(msg, signature).raw_public_key).to eq key.raw_public_key
+
+      privkey = ec_key.private_key.to_s(2)
+      signature = Ciri::Crypto.ecdsa_signature(privkey, msg)
+
+      raw_pubkey = Ciri::Crypto.ecdsa_recover(msg, signature, return_raw_key: true)
+
+      expect(raw_pubkey).to eq ec_key.public_key.to_bn.to_s(2)
     end
 
     it 'pass geth recovery test case' do

--- a/ciri-crypto/spec/ciri/crypto_spec.rb
+++ b/ciri-crypto/spec/ciri/crypto_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2018, by Jiang Jinyang. <https://justjjy.com>, classicalliu.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+# require 'spec_helper'
+require 'ciri/crypto'
+require 'ciri/key'
+
+RSpec.describe Ciri::Crypto do
+  it 'self consistent' do
+    key = OpenSSL::PKey::EC.new('secp256k1')
+    key.generate_key
+    message = 'We are all in the gutter, but some of us are looking at the stars.'
+    encrypt_data = Ciri::Crypto.ecies_encrypt(message, key)
+    text = Ciri::Crypto.ecies_decrypt(encrypt_data, key)
+    expect(text).to eq message
+  end
+
+  context 'ecdsa recover' do
+    it 'self consistent' do
+      key = Ciri::Key.random
+      msg = Ciri::Utils.keccak "hello world"
+      signature = key.ecdsa_signature(msg)
+      expect(Ciri::Key.ecdsa_recover(msg, signature).raw_public_key).to eq key.raw_public_key
+    end
+
+    it 'pass geth recovery test case' do
+      msg = ["ce0677bb30baa8cf067c88db9811f4333d131bf8bcf12fe7065d211dce971008"].pack("H*")
+      signature = ["90f27b8b488db00b00606796d2987f6a5f59ae62ea05effe84fef5b8b0e549984a691139ad57a3f0b906637673aa2f63d1f55cb1a69199d4009eea23ceaddc9301"].pack("H*")
+      pubkey = ["04e32df42865e97135acfb65f3bae71bdc86f4d49150ad6a440b6f15878109880a0a2b2667f7e725ceea70c673093bf67663e0312623c8e091b13cf2c0f11ef652"].pack("H*")
+      raw_key = Ciri::Crypto.ecdsa_recover(msg, signature)
+      expect(raw_key).to eq pubkey
+    end
+  end
+end

--- a/ciri-crypto/spec/spec_helper.rb
+++ b/ciri-crypto/spec/spec_helper.rb
@@ -1,0 +1,14 @@
+require "bundler/setup"
+require "ciri/crypto"
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end

--- a/ciri-rlp/Gemfile.lock
+++ b/ciri-rlp/Gemfile.lock
@@ -2,12 +2,12 @@ PATH
   remote: .
   specs:
     ciri-rlp (0.1.1)
-      ciri-utils (~> 0.1.0)
+      ciri-utils (~> 0.2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ciri-utils (0.1.0)
+    ciri-utils (0.2.0)
       digest-sha3 (~> 1.1.0)
     diff-lcs (1.3)
     digest-sha3 (1.1.0)
@@ -36,4 +36,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/ciri-rlp/ciri-rlp.gemspec
+++ b/ciri-rlp/ciri-rlp.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ciri-utils", "~> 0.1.0"
+  spec.add_dependency "ciri-utils", "~> 0.2.0"
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/ciri.gemspec
+++ b/ciri.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   # components
   spec.add_dependency 'ciri-utils', '~> 0.2.0'
   spec.add_dependency 'ciri-rlp', '~> 0.1.1'
+  spec.add_dependency 'ciri-crypto', '~> 0.1.0'
 
   spec.add_dependency 'ffi', '~> 1.9.23'
   spec.add_dependency 'lru_redux', '~> 1.1.0'

--- a/ciri.gemspec
+++ b/ciri.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   # components
   spec.add_dependency 'ciri-utils', '~> 0.2.0'
   spec.add_dependency 'ciri-rlp', '~> 0.1.1'
-  spec.add_dependency 'ciri-crypto', '~> 0.1.0'
+  spec.add_dependency 'ciri-crypto', '~> 0.1.1'
 
   spec.add_dependency 'ffi', '~> 1.9.23'
   spec.add_dependency 'lru_redux', '~> 1.1.0'

--- a/lib/ciri/key.rb
+++ b/lib/ciri/key.rb
@@ -23,7 +23,7 @@
 
 require 'openssl'
 require 'ciri/utils'
-require_relative 'crypto'
+require 'ciri/crypto'
 
 module Ciri
 

--- a/lib/ciri/trie/nodes.rb
+++ b/lib/ciri/trie/nodes.rb
@@ -23,6 +23,7 @@
 
 require_relative 'nibbles'
 require 'forwardable'
+require 'ciri/utils'
 
 module Ciri
   class Trie

--- a/spec/ciri/key_spec.rb
+++ b/spec/ciri/key_spec.rb
@@ -25,30 +25,13 @@ require 'spec_helper'
 require 'ciri/crypto'
 require 'ciri/key'
 
-RSpec.describe Ciri::Crypto do
-  it 'self consistent' do
-    key = OpenSSL::PKey::EC.new('secp256k1')
-    key.generate_key
-    message = 'We are all in the gutter, but some of us are looking at the stars.'
-    encrypt_data = Ciri::Crypto.ecies_encrypt(message, key)
-    text = Ciri::Crypto.ecies_decrypt(encrypt_data, key)
-    expect(text).to eq message
-  end
-
+RSpec.describe Ciri::Key do
   context 'ecdsa recover' do
     it 'self consistent' do
       key = Ciri::Key.random
       msg = Ciri::Utils.keccak "hello world"
       signature = key.ecdsa_signature(msg)
       expect(Ciri::Key.ecdsa_recover(msg, signature).raw_public_key).to eq key.raw_public_key
-    end
-
-    it 'pass geth recovery test case' do
-      msg = ["ce0677bb30baa8cf067c88db9811f4333d131bf8bcf12fe7065d211dce971008"].pack("H*")
-      signature = ["90f27b8b488db00b00606796d2987f6a5f59ae62ea05effe84fef5b8b0e549984a691139ad57a3f0b906637673aa2f63d1f55cb1a69199d4009eea23ceaddc9301"].pack("H*")
-      pubkey = ["04e32df42865e97135acfb65f3bae71bdc86f4d49150ad6a440b6f15878109880a0a2b2667f7e725ceea70c673093bf67663e0312623c8e091b13cf2c0f11ef652"].pack("H*")
-      raw_key = Ciri::Crypto.ecdsa_recover(msg, signature)
-      expect(raw_key).to eq pubkey
     end
   end
 end


### PR DESCRIPTION
split crypto and key file to a gem named ciri-crypto, aim to split crypto module and can be used standalone.