### PR TITLE
Refactoring EVM call

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,3 @@
 --format progress
 --color
 --require spec_helper
---profile

--- a/Rakefile
+++ b/Rakefile
@@ -59,13 +59,17 @@ namespace :docker do
 
   desc 'run tests in docker'
   task :test do
-    system("docker run -v `pwd`:/app --rm #{base_image}:latest rake test")
+    system(default_env, "docker run -v `pwd`:/app --rm #{base_image}:latest rake test")
     exit $?.exitstatus
   end
 
   desc 'run all tests(include slow tests) in docker'
   task :"test:all" do
-    system("docker run -v `pwd`:/app --rm #{base_image}:latest rake test:all")
+    system(default_env, "docker run -v `pwd`:/app --rm #{base_image}:latest rake test:all")
     exit $?.exitstatus
+  end
+
+  def default_env
+    {'RUBY_THREAD_VM_STACK_SIZE' => ENV['RUBY_THREAD_VM_STACK_SIZE'] || '52428800'}
   end
 end

--- a/docker/Base
+++ b/docker/Base
@@ -30,5 +30,7 @@ RUN apt-get install -y libsnappy-dev
 WORKDIR /app
 COPY . /app
 
+ENV RUBY_THREAD_VM_STACK_SIZE=52428800
+
 # bundle
 RUN bundle install

--- a/lib/ciri/evm.rb
+++ b/lib/ciri/evm.rb
@@ -149,7 +149,7 @@ module Ciri
 
         # refund gas
         refund_gas = fork_schema.calculate_refund_gas(vm)
-        remain_gas = context.calculate_remain_gas
+        remain_gas = context.remain_gas
         gas_used = t.gas_limit - remain_gas
         refund_gas = [refund_gas, gas_used / 2].min
         state.add_balance(t.sender, (refund_gas + remain_gas) * t.gas_price)
@@ -160,7 +160,7 @@ module Ciri
           state.delete_account(address)
         end
 
-        ExecutionResult.new(status: context.status, state_root: state_root, logs: context.sub_state.log_series,
+        ExecutionResult.new(status: context.status, state_root: state_root, logs: context.all_log_series,
                             gas_used: gas_used - refund_gas, gas_price: t.gas_price, exception: context.exception)
       end
     end

--- a/lib/ciri/evm/block_info.rb
+++ b/lib/ciri/evm/block_info.rb
@@ -26,7 +26,20 @@ module Ciri
 
     # Block Info
     BlockInfo = Struct.new(:coinbase, :difficulty, :gas_limit, :number, :timestamp, :block_hash, :parent_hash,
-                           keyword_init: true)
+                           keyword_init: true) do
+
+      def self.from_header(header)
+        BlockInfo.new(
+          coinbase: header.beneficiary,
+          difficulty: header.difficulty,
+          gas_limit: header.gas_limit,
+          number: header.number,
+          timestamp: header.timestamp,
+          parent_hash: header.parent_hash,
+          block_hash: header.get_hash,
+        )
+      end
+    end
 
   end
 end

--- a/lib/ciri/evm/execution_context.rb
+++ b/lib/ciri/evm/execution_context.rb
@@ -59,6 +59,10 @@ module Ciri
         @pc = pc
       end
 
+      def revert
+        @sub_state = SubState::EMPTY
+      end
+
       def status
         exception.nil? ? 0 : 1
       end

--- a/lib/ciri/evm/execution_context.rb
+++ b/lib/ciri/evm/execution_context.rb
@@ -27,11 +27,10 @@ module Ciri
   class EVM
     class ExecutionContext
 
-      attr_accessor :instruction, :depth, :pc, :output, :exception, :gas_limit, :block_info, :sub_state,
-                    :remain_gas, :fork_schema
+      attr_accessor :instruction, :depth, :pc, :output, :exception, :gas_limit, :block_info, :sub_state, :fork_schema
       attr_reader :children
 
-      def initialize(instruction:, depth: 0, gas_limit:, remain_gas: gas_limit, fork_schema:, pc: 0,
+      def initialize(instruction:, depth: 1, gas_limit:, remain_gas: gas_limit, fork_schema:, pc: 0,
                      block_info:, sub_state: SubState::EMPTY.dup)
         raise ArgumentError.new("remain_gas must more than 0") if remain_gas < 0
         raise ArgumentError.new("gas_limit must more than 0") if gas_limit < 0
@@ -74,7 +73,7 @@ module Ciri
           pc: pc,
           gas_limit: gas_limit,
           block_info: block_info,
-          sub_state: sub_state,
+          sub_state: sub_state.dup,
           remain_gas: gas_limit,
           fork_schema: fork_schema,
         )
@@ -93,8 +92,12 @@ module Ciri
       end
 
       # remain gas of context
-      def calculate_remain_gas
+      def remain_gas
         @remain_gas - children.reduce(0) {|s, c| s + c.used_gas}
+      end
+
+      def all_log_series
+        sub_state.log_series + children.map {|c| c.all_log_series}.flatten
       end
 
     end

--- a/lib/ciri/evm/execution_context.rb
+++ b/lib/ciri/evm/execution_context.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2018, by Jiang Jinyang. <https://justjjy.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+require 'ciri/evm/errors'
+
+module Ciri
+  class EVM
+    class ExecutionContext
+
+      attr_accessor :instruction, :depth, :pc, :output, :exception, :gas_limit, :block_info, :sub_state,
+                    :remain_gas, :fork_schema
+      attr_reader :children
+
+      def initialize(instruction:, depth: 0, gas_limit:, remain_gas: gas_limit, fork_schema:, pc: 0,
+                     block_info:, sub_state: SubState::EMPTY.dup)
+        raise ArgumentError.new("remain_gas must more than 0") if remain_gas < 0
+        raise ArgumentError.new("gas_limit must more than 0") if gas_limit < 0
+
+        @instruction = instruction
+        @depth = depth
+        @gas_limit = gas_limit
+        @block_info = block_info
+        @sub_state = sub_state
+        @remain_gas = remain_gas
+        @fork_schema = fork_schema
+        @pc = pc
+        @children = []
+      end
+
+      def set_exception(e)
+        @exception ||= e
+      end
+
+      def set_output(output)
+        @output ||= output
+      end
+
+      def set_pc(pc)
+        @pc = pc
+      end
+
+      def status
+        exception.nil? ? 0 : 1
+      end
+
+      def child_context(instruction: self.instruction.dup, depth: self.depth + 1, pc: 0, gas_limit:)
+        child = ExecutionContext.new(
+          instruction: instruction,
+          depth: depth,
+          pc: pc,
+          gas_limit: gas_limit,
+          block_info: block_info,
+          sub_state: sub_state,
+          remain_gas: gas_limit,
+          fork_schema: fork_schema,
+        )
+        children << child
+        child
+      end
+
+      def consume_gas(gas)
+        raise GasNotEnoughError.new("can't consume gas to negative, remain_gas: #{remain_gas}, consumed: #{gas}") if gas > remain_gas
+        @remain_gas -= gas
+      end
+
+    end
+  end
+end

--- a/lib/ciri/evm/execution_context.rb
+++ b/lib/ciri/evm/execution_context.rb
@@ -83,6 +83,16 @@ module Ciri
         @remain_gas -= gas
       end
 
+      # used gas of context
+      def used_gas
+        @gas_limit - @remain_gas
+      end
+
+      # remain gas of context
+      def calculate_remain_gas
+        @remain_gas - children.reduce(0) {|s, c| s + c.used_gas}
+      end
+
     end
   end
 end

--- a/lib/ciri/evm/instruction.rb
+++ b/lib/ciri/evm/instruction.rb
@@ -25,15 +25,14 @@ module Ciri
   class EVM
 
     # represent instruction
-    Instruction = Struct.new(:address, :origin, :price, :data, :sender, :value, :bytes_code, :header, :execute_depth,
-                             keyword_init: true) do
+    Instruction = Struct.new(:address, :origin, :price, :data, :sender, :value, :bytes_code,
+                             :header, keyword_init: true) do
 
       def initialize(*args)
         super
         self.data ||= ''.b
         self.value ||= 0
         self.bytes_code ||= ''.b
-        self.execute_depth ||= 0
       end
 
       def get_op(pos)

--- a/lib/ciri/evm/op.rb
+++ b/lib/ciri/evm/op.rb
@@ -328,8 +328,8 @@ module Ciri
 
       def_op :MLOAD, 0x51, 1, 1 do |vm|
         index = vm.pop(Integer)
-        vm.push vm.memory_fetch(index, 32)
         vm.extend_memory(index, 32)
+        vm.push vm.memory_fetch(index, 32)
       end
 
       def_op :MSTORE, 0x52, 2, 0 do |vm|
@@ -447,43 +447,15 @@ module Ciri
       end
 
       def_op :CALL, 0xf1, 7, 1 do |vm|
-        gas_limit = vm.pop(Integer)
-        target = vm.pop(Address)
-        value = vm.pop(Integer)
-        input_mem_pos, input_size = vm.pop_list(2, Integer)
-        output_mem_pos, output_mem_size = vm.pop_list(2, Integer)
-
-        data = vm.memory_fetch(input_mem_pos, input_size)
-        vm.extend_memory(input_mem_pos, input_size)
-        context = vm.execution_context.child_context(gas_limit: gas_limit)
-        status, output = vm.call_message(sender: vm.instruction.address, value: value, data: data, target: target,
-                                         code_address: target, context: context)
-
-        output_size = [output_mem_size, output.size].min
-        vm.extend_memory(output_mem_pos, output_size)
-        vm.memory_store(output_mem_pos, output_size, output)
-        vm.push status
+        gas, to, value, data, output_mem_pos, output_mem_size = extract_call_argument(vm)
+        call_message(vm: vm, sender: vm.instruction.address, value: value, gas: gas, to: to,
+                     data: data, code_address: to, output_mem_pos: output_mem_pos, output_mem_size: output_mem_size)
       end
 
       def_op :CALLCODE, 0xf2, 7, 1 do |vm|
-        # this method consume 7 items from stack, but seems not all of them are used
-        gas_limit = vm.pop(Integer)
-        target = vm.pop(Address)
-        value = vm.pop(Integer)
-        input_mem_pos, input_size = vm.pop_list(2, Integer)
-        output_mem_pos, output_mem_size = vm.pop_list(2, Integer)
-
-        vm.extend_memory(input_mem_pos, input_size)
-        data = vm.memory_fetch(input_mem_pos, input_size)
-
-        context = vm.execution_context.child_context(gas_limit: gas_limit)
-        status, output = vm.call_message(sender: vm.instruction.address, value: value, data: data,
-                                         target: vm.instruction.address, code_address: target, context: context)
-
-        output_size = [output_mem_size, output.size].min
-        vm.extend_memory(output_mem_pos, output_size)
-        vm.memory_store(output_mem_pos, output_size, output)
-        vm.push status
+        gas, to, value, data, output_mem_pos, output_mem_size = extract_call_argument(vm)
+        call_message(vm: vm, sender: vm.instruction.address, value: value, gas: gas, to: vm.instruction.address,
+                     data: data, code_address: to, output_mem_pos: output_mem_pos, output_mem_size: output_mem_size)
       end
 
       def_op :RETURN, 0xf3, 2, 0 do |vm|
@@ -493,22 +465,10 @@ module Ciri
       end
 
       def_op :DELEGATECALL, 0xf4, 6, 1 do |vm|
-        gas_limit = vm.pop(Integer)
-        target = vm.pop(Address)
-        input_mem_pos, input_size = vm.pop_list(2, Integer)
-        output_mem_pos, output_mem_size = vm.pop_list(2, Integer)
-
-        data = vm.memory_fetch(input_mem_pos, input_size)
-        vm.extend_memory(input_mem_pos, input_size)
-
-        context = vm.execution_context.child_context(gas_limit: gas_limit)
-        status, output = vm.call_message(sender: vm.instruction.sender, value: vm.instruction.value, data: data,
-                                         target: vm.instruction.address, code_address: target, context: context)
-
-        output_size = [output_mem_size, output.size].min
-        vm.extend_memory(output_mem_pos, output_size)
-        vm.memory_store(output_mem_pos, output_size, output)
-        vm.push status
+        gas, to, _value, data, output_mem_pos, output_mem_size = extract_call_argument(vm, delegate_call: true)
+        call_message(vm: vm, sender: vm.instruction.sender, value: vm.instruction.value, gas: gas,
+                     to: vm.instruction.address, data: data, code_address: to,
+                     output_mem_pos: output_mem_pos, output_mem_size: output_mem_size)
       end
 
       STATICCALL = 0xfa
@@ -542,6 +502,34 @@ module Ciri
         # register changed accounts
         vm.add_refund_account(refund_address)
         vm.add_suicide_account(vm.instruction.address)
+      end
+
+      private
+
+      def self.extract_call_argument(vm, delegate_call: false)
+        gas = vm.pop(Integer)
+        to = vm.pop(Address)
+        value = delegate_call ? 0 : vm.pop(Integer)
+        input_mem_pos, input_size = vm.pop_list(2, Integer)
+        vm.extend_memory(input_mem_pos, input_size)
+        data = vm.memory_fetch(input_mem_pos, input_size)
+        output_mem_pos, output_mem_size = vm.pop_list(2, Integer)
+        [gas, to, value, data, output_mem_pos, output_mem_size]
+      end
+
+      def self.call_message(vm:, gas:, sender:, value:, data:, to:, code_address: to, output_mem_pos:, output_mem_size:)
+        context = vm.execution_context
+        child_gas_limit, child_gas_fee = context.fork_schema.gas_of_call(context: context,
+                                                                         gas: gas, to: to, value: value)
+        context.consume_gas(child_gas_fee)
+        child_context = context.child_context(gas_limit: child_gas_limit)
+        status, output = vm.call_message(sender: sender, value: value, data: data, target: to,
+                                         code_address: code_address, context: child_context)
+
+        output_size = [output_mem_size, output.size].min
+        vm.extend_memory(output_mem_pos, output_size)
+        vm.memory_store(output_mem_pos, output_size, output)
+        vm.push status
       end
 
     end

--- a/lib/ciri/evm/op.rb
+++ b/lib/ciri/evm/op.rb
@@ -447,7 +447,7 @@ module Ciri
       end
 
       def_op :CALL, 0xf1, 7, 1 do |vm|
-        vm.pop
+        gas_limit = vm.pop(Integer)
         target = vm.pop(Address)
         value = vm.pop(Integer)
         input_mem_pos, input_size = vm.pop_list(2, Integer)
@@ -455,9 +455,9 @@ module Ciri
 
         data = vm.memory_fetch(input_mem_pos, input_size)
         vm.extend_memory(input_mem_pos, input_size)
-
-        status, output = vm.call_message(sender: vm.instruction.address, value: value,
-                                         data: data, target: target, code_address: target)
+        context = vm.execution_context.child_context(gas_limit: gas_limit)
+        status, output = vm.call_message(sender: vm.instruction.address, value: value, data: data, target: target,
+                                         code_address: target, context: context)
 
         output_size = [output_mem_size, output.size].min
         vm.extend_memory(output_mem_pos, output_size)
@@ -467,8 +467,7 @@ module Ciri
 
       def_op :CALLCODE, 0xf2, 7, 1 do |vm|
         # this method consume 7 items from stack, but seems not all of them are used
-        # skip item
-        vm.pop
+        gas_limit = vm.pop(Integer)
         target = vm.pop(Address)
         value = vm.pop(Integer)
         input_mem_pos, input_size = vm.pop_list(2, Integer)
@@ -477,8 +476,9 @@ module Ciri
         vm.extend_memory(input_mem_pos, input_size)
         data = vm.memory_fetch(input_mem_pos, input_size)
 
-        status, output = vm.call_message(sender: vm.instruction.address, value: value,
-                                         data: data, target: vm.instruction.address, code_address: target)
+        context = vm.execution_context.child_context(gas_limit: gas_limit)
+        status, output = vm.call_message(sender: vm.instruction.address, value: value, data: data,
+                                         target: vm.instruction.address, code_address: target, context: context)
 
         output_size = [output_mem_size, output.size].min
         vm.extend_memory(output_mem_pos, output_size)
@@ -493,7 +493,7 @@ module Ciri
       end
 
       def_op :DELEGATECALL, 0xf4, 6, 1 do |vm|
-        vm.pop
+        gas_limit = vm.pop(Integer)
         target = vm.pop(Address)
         input_mem_pos, input_size = vm.pop_list(2, Integer)
         output_mem_pos, output_mem_size = vm.pop_list(2, Integer)
@@ -501,8 +501,9 @@ module Ciri
         data = vm.memory_fetch(input_mem_pos, input_size)
         vm.extend_memory(input_mem_pos, input_size)
 
-        status, output = vm.call_message(sender: vm.instruction.sender, value: vm.instruction.value,
-                                         data: data, target: vm.instruction.address, code_address: target)
+        context = vm.execution_context.child_context(gas_limit: gas_limit)
+        status, output = vm.call_message(sender: vm.instruction.sender, value: vm.instruction.value, data: data,
+                                         target: vm.instruction.address, code_address: target, context: context)
 
         output_size = [output_mem_size, output.size].min
         vm.extend_memory(output_mem_pos, output_size)

--- a/lib/ciri/evm/op.rb
+++ b/lib/ciri/evm/op.rb
@@ -381,7 +381,7 @@ module Ciri
       end
 
       def_op :GAS, 0x5a, 0, 1 do |vm|
-        vm.push vm.machine_state.remain_gas
+        vm.push vm.remain_gas
       end
 
       def_op :JUMPDEST, 0x5b, 0, 0
@@ -489,7 +489,7 @@ module Ciri
       def_op :RETURN, 0xf3, 2, 0 do |vm|
         index, size = vm.pop_list(2, Integer)
         vm.extend_memory(index, size)
-        vm.output = vm.memory_fetch(index, size)
+        vm.set_output vm.memory_fetch(index, size)
       end
 
       def_op :DELEGATECALL, 0xf4, 6, 1 do |vm|

--- a/lib/ciri/evm/vm.rb
+++ b/lib/ciri/evm/vm.rb
@@ -192,6 +192,7 @@ module Ciri
               debug("exception: #{exception}, burn gas #{remain_gas} to zero")
               consume_gas remain_gas
             end
+            execution_context.revert
             return [EMPTY_SET, machine_state, SubState::EMPTY, instruction, EMPTY_SET]
           elsif get_op(pc) == OP::REVERT
             o = halt
@@ -221,7 +222,6 @@ module Ciri
 
       # O(σ, μ, A, I) ≡ (σ′, μ′, A′, I)
       def operate
-        ms = machine_state
         w = get_op(pc)
         operation = OP.get(w)
 
@@ -239,7 +239,7 @@ module Ciri
 
         # revert sub_state and return if exception occur
         if exception
-          @sub_state = SubState::EMPTY
+          execution_context.revert
           return
         end
 

--- a/lib/ciri/forks/base.rb
+++ b/lib/ciri/forks/base.rb
@@ -34,6 +34,10 @@ module Ciri
         raise NotImplementedError
       end
 
+      def gas_of_call(context:, gas:, to:, value:)
+        raise NotImplementedError
+      end
+
       def intrinsic_gas_of_transaction(transaction)
         raise NotImplementedError
       end

--- a/lib/ciri/forks/frontier.rb
+++ b/lib/ciri/forks/frontier.rb
@@ -40,6 +40,10 @@ module Ciri
           Cost.cost_of_memory word_count
         end
 
+        def gas_of_call(context:, gas:, to:, value:)
+          Cost.gas_of_call(context: context, gas: gas, to: to, value: value)
+        end
+
         def intrinsic_gas_of_transaction(transaction)
           Cost.intrinsic_gas_of_transaction transaction
         end

--- a/lib/ciri/forks/frontier/cost.rb
+++ b/lib/ciri/forks/frontier/cost.rb
@@ -151,14 +151,18 @@ module Ciri
             gas + G_TRANSACTION
           end
 
+          def gas_of_call(context:, gas:, to:, value:)
+            # extra_gas = self.compute_msg_extra_gas(computation, gas, to, value)
+            # total_fee = gas + extra_gas
+            total_fee = 0
+            child_gas_limit = gas + (value > 0 ? G_CALLSTIPEND : 0)
+            [child_gas_limit, total_fee]
+          end
+
           private
 
           def cost_of_self_destruct(vm)
             G_SELFDESTRUCT
-          end
-
-          def cost_of_call
-
           end
 
           def cost_of_sstore(vm)

--- a/lib/ciri/forks/frontier/cost.rb
+++ b/lib/ciri/forks/frontier/cost.rb
@@ -93,7 +93,7 @@ module Ciri
           def cost_of_operation(vm)
             ms = vm.machine_state
             instruction = vm.instruction
-            w = instruction.get_op(ms.pc)
+            w = instruction.get_op(vm.pc)
             if w == SSTORE
               cost_of_sstore(vm)
             elsif w == EXP && ms.get_stack(1, Integer) == 0

--- a/lib/ciri/types/address.rb
+++ b/lib/ciri/types/address.rb
@@ -61,7 +61,7 @@ module Ciri
       end
 
       def empty?
-        @address.empty? || @address.each_byte.reduce(0, :+).zero?
+        @address.empty?
       end
 
       def validate

--- a/spec/ciri/fixtures_tests/block_chain_spec.rb
+++ b/spec/ciri/fixtures_tests/block_chain_spec.rb
@@ -229,9 +229,9 @@ RSpec.describe Ciri::Chain do
     end
   end if true
 
-    # Dir.glob("fixtures/BlockchainTests/bcMultiChainTest/*").each do |topic|
-    # topic ||= nil
-    # run_test_case[JSON.load(open topic || 'fixtures/BlockchainTests/bcUncleHeaderValidity/timestampTooLow.json'), prefix: 'test', tags: {}]
+  # Dir.glob("fixtures/BlockchainTests/bcMultiChainTest/*").each do |topic|
+  # topic ||= nil
+  # run_test_case[JSON.load(open topic || 'fixtures/BlockchainTests/bcValidBlockTest/callRevert.json'), prefix: 'test', tags: {}]
   # end
 
 end

--- a/spec/ciri/fixtures_tests/block_chain_spec.rb
+++ b/spec/ciri/fixtures_tests/block_chain_spec.rb
@@ -199,7 +199,6 @@ RSpec.describe Ciri::Chain do
   broken_topics = %w{
     bcExploitTest
     bcStateTests
-    bcUncleHeaderValidity
     bcWalletTest
     bcForkStressTest
     bcRandomBlockhashTest
@@ -230,9 +229,9 @@ RSpec.describe Ciri::Chain do
     end
   end if true
 
-  # Dir.glob("fixtures/BlockchainTests/bcMultiChainTest/*").each do |topic|
-  # topic ||= nil
-  # run_test_case[JSON.load(open topic || 'fixtures/BlockchainTests/TransitionTests/bcFrontierToHomestead/HomesteadOverrideFrontier.json'), prefix: 'test', tags: {}]
+    # Dir.glob("fixtures/BlockchainTests/bcMultiChainTest/*").each do |topic|
+    # topic ||= nil
+    # run_test_case[JSON.load(open topic || 'fixtures/BlockchainTests/bcUncleHeaderValidity/timestampTooLow.json'), prefix: 'test', tags: {}]
   # end
 
 end

--- a/spec/ciri/fixtures_tests/evm_state_spec.rb
+++ b/spec/ciri/fixtures_tests/evm_state_spec.rb
@@ -107,10 +107,14 @@ RSpec.describe Ciri::EVM do
               transaction.sender
 
               evm = Ciri::EVM.new(state: state)
-              evm.execute_transaction(transaction, block_info: block_info, ignore_exception: true) rescue nil
+              result = begin
+                evm.execute_transaction(transaction, block_info: block_info, ignore_exception: true)
+              rescue Ciri::EVM::Error
+                Ciri::EVM::ExecutionResult.new(logs: [])
+              end
 
               if config['logs']
-                expect(Ciri::Utils.to_hex evm.logs_hash).to eq config['logs']
+                expect(Ciri::Utils.to_hex result.logs_hash).to eq config['logs']
               end
 
             end
@@ -154,6 +158,7 @@ RSpec.describe Ciri::EVM do
     tags = {}
     # tag slow test topics
     if slow_topics.include?(topic)
+      skip topic
       tags[:slow_tests] = true
     end
 

--- a/spec/ciri/fixtures_tests/evm_state_spec.rb
+++ b/spec/ciri/fixtures_tests/evm_state_spec.rb
@@ -68,16 +68,15 @@ RSpec.describe Ciri::EVM do
 
         # transaction
         transaction_arguments = t['transaction']
-
-        env = t['env'] && t['env'].map {|k, v| [k, Ciri::Utils.to_bytes(v)]}.to_h
+        env = t['env']
 
         # env
         block_info = env && Ciri::EVM::BlockInfo.new(
-          coinbase: env['currentCoinbase'],
-          difficulty: env['currentDifficulty'],
-          gas_limit: env['currentGasLimit'],
-          number: env['currentNumber'],
-          timestamp: env['currentTimestamp'],
+          coinbase: Ciri::Utils.to_bytes(env['currentCoinbase']),
+          difficulty: Ciri::Utils.hex_to_number(env['currentDifficulty']),
+          gas_limit: Ciri::Utils.hex_to_number(env['currentGasLimit']),
+          number: Ciri::Utils.hex_to_number(env['currentNumber']),
+          timestamp: Ciri::Utils.hex_to_number(env['currentTimestamp']),
         )
 
         t['post'].each do |fork_name, configs|
@@ -158,7 +157,6 @@ RSpec.describe Ciri::EVM do
     tags = {}
     # tag slow test topics
     if slow_topics.include?(topic)
-      skip topic
       tags[:slow_tests] = true
     end
 


### PR DESCRIPTION
Use `EVM::ExecutionContext` to save EVM states, make `EVM` class more clear.